### PR TITLE
Remove absolute paths from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,25 +14,15 @@ FetchContent_MakeAvailable(json)
 add_subdirectory(lib)
 add_subdirectory(benchmarks)
 
+set(IBEX_INSTALL_DIR "/usr/local" CACHE PATH "Ibex installation directory")
+
 include_directories(include
-            /usr/local/include
-            /usr/local/include/ibex
-            /usr/local/include/soplex
-            /usr/local/include/ibex/3rd
-            /usr/local/include/ibex/3rd/gaol
-            # CHPC specififc paths
-            /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/include
-            /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/include/ibex
-            /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/__build__/3rd/include
-            /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/__build__/3rd/include/gaol
-            /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/__build__/3rd/include/soplex)
-link_directories(/usr/local/lib
-                /usr/local/lib64
-                /home/tanmay/Downloads/ibex-lib-ibex-2.8.9/build/interval_lib_wrapper/gaol/gaol-4.2.0/lib
-                /home/tanmay/Downloads/ibex-lib-ibex-2.8.9/build/interval_lib_wrapper/gaol/mathlib-2.1.0/lib
-                # CHPC specififc paths
-                /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/__build__/src
-                /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/__build__/3rd/lib)
+    ${IBEX_INSTALL_DIR}/include
+    ${IBEX_INSTALL_DIR}/include/ibex
+    ${IBEX_INSTALL_DIR}/include/ibex/3rd)
+
+link_directories(${IBEX_INSTALL_DIR}/lib
+    ${IBEX_INSTALL_DIR}/lib/ibex/3rd)
 
 option(ENABLE_LLVM_FRONTEND "Enable the LLVM frontend" OFF)
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,51 @@
 # CIRE: C++ Incremental rigorous error-analyser
 
-CIRE is similar to [SATIRE](https://github.com/arnabd88/Satire) but in C++. This project was meant to provide an error analysis tool and
-library for C/C++ programs. Ideally it should have all the capabilities of Satire and
-more.
+CIRE is similar to [SATIRE](https://github.com/arnabd88/Satire) but in C++.
+This project was meant to provide an error analysis tool and library for C/C++ programs.
+Ideally it should have all the capabilities of Satire and more.
+
 
 # Dependencies
 
-CIRE requires the following softwares installed on your system. The tool will not build unless these are installed.
+CIRE requires the following softwares installed on your system.
+The tool will not build unless these are installed.
 
-* ibex-lib > 2.8.9 [Install Notes](#ibex-installation)
+* ibex-lib >= 2.8.9 [Install Notes](#ibex-installation)
   * [Github](https://github.com/ibex-team/ibex-lib)
   * [Original Installation instructions](http://ibex-team.github.io/ibex-lib/install.html)
-* python2.x > 2.7 (Ibex scripts are currently not compatible with python3)
-* g++ (version 13 because of IBEX)
-* gcc (version 13 because of IBEX)
+* python2.x >= 2.7 (Ibex scripts are currently not compatible with python3)
+* g++ >= 13 (because of IBEX)
+* gcc >= 13 (because of IBEX)
 * bison
 * flex
 * cmake
 
 ### If you want to use the LLVM frontend
-* LLVM > 16
+
+* LLVM >= 16
+
 This version is necessary since the frontend uses the new pass manager by default.
-Use gcc (version 13) to build LLVM to ensure standard libraries are compatible with CIRE and IBEX
+Use gcc (version 13) to build LLVM to ensure standard libraries are compatible with CIRE and IBEX.
+LLVM 16 has been tested to work.
 
 ## IBEX installation
+
 ### Linux and MacOS
-Use `wget` command below or download `ibex-lib-ibex-2.8.9.tar.gz` (the tar file) from 
-[here](https://github.com/ibex-team/ibex-lib/releases/tag/ibex-2.8.9).
+
+Use `wget` command below or download `ibex-lib-ibex-2.8.9.tar.gz` (the tar file) from
+[the GitHub release page](https://github.com/ibex-team/ibex-lib/releases/tag/ibex-2.8.9).
+
 ```bash
 wget https://github.com/ibex-team/ibex-lib/archive/refs/tags/ibex-2.8.9.tar.gz
 ```
 
 #### Installing IBEX through waflib (RECOMMENDED)
+
 ```bash
 tar xvfz ibex-2.8.9.tgz
 cd ibex-2.8.9
-sudo ./waf configure [--enable-shared]
-sudo ./waf install
+./waf configure --lp-lib=soplex [--enable-shared]
+./waf install
 ```
 
 **In case the waflib configuration fails** for some reason, you may need to install one or more of the libraries listed below, 
@@ -50,17 +59,19 @@ to build the libraries that the CMake system fails to build.
 So after unzipping ibex tar ball and moving into the unzipped folder,
 
 #### Installing Soplex
+
 ```bash
 cd lp_lib_wrapper/soplex/3rd
 tar soplex-4.0.2.tar
 cd soplex-4.0.2
 mkdir build && cd build
-cmake ..
+cmake .. -DLP_LIB=soplex
 make -j16 USRCPPFLAGS=-fPIC
 sudo make install
 ```
 
 #### Installing IBEX through CMake
+
 ```bash
 mkdir build && cd build
 cmake -DLP_LIB=soplex ..
@@ -68,25 +79,13 @@ make -j16
 sudo make install
 ```
 
-#### To Uninstall 
-##### If waflib was used to install
-```bash
-sudo ./waf uninstall
-sudo ./waf distclean
-```
-
-##### If CMake was used to install
-```bash
-cd build
-sudo make uninstall
-```
 
 # Building CIRE
 
 The CMakeLists.txt file is configured to build the library and the executable in the build directory.
 Make sure the shared library files are in your PATH. If not, set the LD_LIBRARY_PATH environment variable to where your
 shared library files are located.
-Then run the following
+Then run the following:
 
 ```bash
 mkdir build-debug
@@ -97,21 +96,24 @@ make
 
 ## Building the LLVM frontend
 
-To build the LLVM frontend, you need to have LLVM installed on your system. Pass `-DENABLE_LLVM_FRONTEND=ON` and set 
-`LT_LLVM_INSTALL_DIR` to the directory where LLVM is installed.
+To build the LLVM frontend, you need to have a build of LLVM 16 or newer on your system.
+Pass `-DENABLE_LLVM_FRONTEND=ON` to cmake and set `LT_LLVM_INSTALL_DIR` to the directory where LLVM is installed.
 
 ```bash
-cmake 
-  -DENABLE_LLVM_FRONTEND=ON
-  -DLT_LLVM_INSTALL_DIR=<path to LLVM install directory> 
-  ..
+cmake -DENABLE_LLVM_FRONTEND=ON                               \
+      -DLT_LLVM_INSTALL_DIR=<path to LLVM install directory>  \
+      ..
 ```
+
 ## Targets
+
 ### CIRE
+
 Uses the SATIRE DSL frontend.
 ```bash
 make CIRE
 ```
+
 
 # Usage
 
@@ -119,25 +121,28 @@ The executable is located in the build-debug directory. Run the following to see
 
 ```bash
 LD_LIBRARY_PATH=/usr/local/lib
-./build-debug/CIRE ./benchmarks/addition/addition.txt
+CIRE ./benchmarks/addition/addition.txt
 ```
 
 ## LLVM Frontend
-There are two ways to utilize the LLVM Frontend. As an LLVM pass or as a standalone tool.
-Make sure you run -O1 or higher to generate LLVM IR to simplify the function removing all memory operations.
+
+There are two ways to utilize the LLVM Frontend: as an LLVM pass or as a standalone tool.
+Make sure you run `-O1` or higher to generate LLVM IR to simplify the function, removing all memory operations.
 
 ```bash
 clang -S -emit-llvm -O1 <path/to/c/file>
 ```
 
 ### As an LLVM pass
+
 ```bash
 <path/to/opt> -load-pass-plugin=<path/to/libCIRE_LLVM.so> -passes="cire" --function=<function_name> --input=<path/to/.txt/file> --disable-output <path/to/llvm/ir/file>
 ```
 
 ### As a standalone tool
+
 ```bash
-./build-debug/CIRE_LLVM <path/to/llvm/ir/file> --function=<function_name> --input=<path/to/.txt/file>
+CIRE_LLVM <path/to/llvm/ir/file> --function=<function_name> --input=<path/to/.txt/file>
 ```
 
 ## Writing LLVM tests

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,24 +2,15 @@
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/..
-            /usr/local/include
-            /usr/local/include/ibex
-            /usr/local/include/soplex
-            /usr/local/include/ibex/3rd
-            /usr/local/include/ibex/3rd/gaol
-            # CHPC specififc paths
-            /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/include
-            /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/include/ibex
-            /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/__build__/3rd/include
-            /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/__build__/3rd/include/gaol
-            /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/__build__/3rd/include/soplex)
-link_directories(/usr/local/lib
-                /usr/local/lib64
-                # CHPC specififc paths
-                /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/__build__/src
-                /uufs/chpc.utah.edu/common/home/u1260704/Tools/ibex-lib-ibex-2.8.9/__build__/3rd/lib)
+set(IBEX_INSTALL_DIR "/usr/local" CACHE PATH "Ibex installation directory")
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/..
+    ${IBEX_INSTALL_DIR}/include
+    ${IBEX_INSTALL_DIR}/include/ibex
+    ${IBEX_INSTALL_DIR}/include/ibex/3rd)
+
+link_directories(${IBEX_INSTALL_DIR}/lib
+    ${IBEX_INSTALL_DIR}/lib/ibex/3rd)
 
 BISON_TARGET(MyParser
         parser.y ${CMAKE_CURRENT_BINARY_DIR}/parser.cpp


### PR DESCRIPTION
Added a variable to CMakeLists named `IBEX_INSTALL_DIR`. Also documented this in the readme. But basically, instead of using absolute paths, we pass a cmake arg like we do with `LT_LLVM_INSTALL_DIR`. E.g.,

```bash
cmake .. -DENABLE_LLVM_FRONTEND=ON -DLT_LLVM_INSTALL_DIR=~/libs/llvm-16-install -DIBEX_INSTALL_DIR=~/libs/ibex-2.8.9-install
```